### PR TITLE
perf: scale Redis throughput (pool + EXPIRE coalescing)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,8 @@ jobs:
           echo "Server is running!"
 
       - name: Run k6 tests
+        env:
+          BASE_URL: http://localhost:8080
         run: |
           # Run the performance tests
           k6 run --vus 10 --duration 30s ./tests/performance.js

--- a/main.go
+++ b/main.go
@@ -82,18 +82,24 @@ func init() {
 		log.Fatalf("Redis DB must be between 0-16: %v", DbNum)
 	}
 
-	Client = redis.NewClient(&redis.Options{
-		Addr:     ADDR, // Redis server address
-		Username: os.Getenv("REDIS_USERNAME"),
-		Password: os.Getenv("REDIS_PASSWORD"),
-		DB:       DbNum,
-	})
-	RateLimitClient = redis.NewClient(&redis.Options{
-		Addr:     ADDR, // Redis server address
-		Username: os.Getenv("REDIS_USERNAME"),
-		Password: os.Getenv("REDIS_PASSWORD"),
-		DB:       DbNum + 1,
-	})
+	// Default pool of 10 was getting timed out tens of thousands of times per
+	// day under load. Redis instance is dedicated to this app, so we can lean
+	// on it. PoolTimeout = 1.2s = fail-fast (vs the 4s default).
+	poolOpts := func(db int) *redis.Options {
+		return &redis.Options{
+			Addr:         ADDR,
+			Username:     os.Getenv("REDIS_USERNAME"),
+			Password:     os.Getenv("REDIS_PASSWORD"),
+			DB:           db,
+			PoolSize:     100,
+			MinIdleConns: 10,
+			ReadTimeout:  500 * time.Millisecond,
+			WriteTimeout: 500 * time.Millisecond,
+			PoolTimeout:  1200 * time.Millisecond,
+		}
+	}
+	Client = redis.NewClient(poolOpts(DbNum))
+	RateLimitClient = redis.NewClient(poolOpts(DbNum + 1))
 }
 
 func setupMockRedis() {

--- a/main.go
+++ b/main.go
@@ -337,6 +337,14 @@ func main() {
 	if RateLimitClient != nil {
 		RateLimitClient.AddHook(utils.RedisTimingHook{Pool: "ratelimit"})
 	}
+	// Coalesce EXPIRE calls — TTL is 6 months, refreshing more than once an
+	// hour per key is wasted bandwidth. Tunable via env for the cautious.
+	gateInterval, err := time.ParseDuration(getEnv("EXPIRE_COALESCE_INTERVAL", "1h"))
+	if err != nil {
+		gateInterval = time.Hour
+	}
+	utils.InitExpireGate(gateInterval, 1_000_000)
+
 	utils.InitMetrics(ctx, Client, RateLimitClient)
 	utils.InitPrometheus(ctx, getEnv("METRICS_ADDR", ":9091"), Client, RateLimitClient)
 	startPprofServer(ctx)

--- a/main.go
+++ b/main.go
@@ -339,8 +339,10 @@ func main() {
 	}
 	// Coalesce EXPIRE calls — TTL is 6 months, refreshing more than once an
 	// hour per key is wasted bandwidth. Tunable via env for the cautious.
-	gateInterval, err := time.ParseDuration(getEnv("EXPIRE_COALESCE_INTERVAL", "1h"))
+	gateIntervalRaw := getEnv("EXPIRE_COALESCE_INTERVAL", "1h")
+	gateInterval, err := time.ParseDuration(gateIntervalRaw)
 	if err != nil {
+		log.Printf("warn: EXPIRE_COALESCE_INTERVAL=%q is not a valid duration (%v); defaulting to 1h", gateIntervalRaw, err)
 		gateInterval = time.Hour
 	}
 	utils.InitExpireGate(gateInterval, 1_000_000)

--- a/routes.go
+++ b/routes.go
@@ -159,7 +159,9 @@ func HitView(c *gin.Context) {
 	go func() {
 		utils.SetStream(dbKey, int(val)) // #nosec G115 -- This is safe as we perform a check (
 		// see above) to ensure val is within the range of an int.
-		Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		if utils.ExpireGate.ShouldRefresh(dbKey) {
+			Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		}
 	}()
 	if c.Query("callback") != "" {
 		c.JSONP(http.StatusOK, gin.H{"value": val})
@@ -195,7 +197,9 @@ func HitShieldView(c *gin.Context) {
 	go func() {
 		utils.SetStream(dbKey, int(val)) // #nosec G115 -- This is safe as we perform a check (
 		// see above) to ensure val is within the range of an int.
-		Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		if utils.ExpireGate.ShouldRefresh(dbKey) {
+			Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		}
 	}()
 
 	badgeSVG, err := utils.GenerateBadge(c, val)
@@ -230,7 +234,9 @@ func GetView(c *gin.Context) {
 	}
 
 	go func() {
-		Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		if utils.ExpireGate.ShouldRefresh(dbKey) {
+			Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		}
 	}()
 	intval, _ := strconv.Atoi(val)
 	if c.Query("callback") != "" {
@@ -263,7 +269,9 @@ func GetShieldView(c *gin.Context) {
 	}
 
 	go func() {
-		Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		if utils.ExpireGate.ShouldRefresh(dbKey) {
+			Client.Expire(context.Background(), dbKey, utils.BaseTTLPeriod)
+		}
 	}()
 
 	intval, convErr := strconv.ParseInt(val, 10, 64)

--- a/utils/expire_coalesce.go
+++ b/utils/expire_coalesce.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,7 +19,8 @@ import (
 // duplicate EXPIRE is idempotent. There is no cross-instance coordination
 // cost, which is the point.
 type ExpireCoalescer struct {
-	m        sync.Map // key string -> int64 unix-nano of last refresh
+	m sync.Map // key string -> int64 unix-nano of last refresh
+
 	interval time.Duration
 
 	// Bounded eviction: when entries exceed maxEntries, the periodic sweeper
@@ -26,17 +28,34 @@ type ExpireCoalescer struct {
 	// without bound across the long tail of one-shot keys.
 	maxEntries int
 
-	Refreshed atomic.Uint64 // observed by Prometheus gauge
+	// size is kept in sync with the map so Prometheus scrapes don't have to
+	// walk the whole sync.Map on every poll.
+	size atomic.Int64
+
+	Refreshed atomic.Uint64 // observed by Prometheus
 	Skipped   atomic.Uint64
+
+	// stop cancels the background sweeper. Allows InitExpireGate to be called
+	// more than once without leaking goroutines on the orphaned coalescer.
+	stop context.CancelFunc
 }
 
 // NewExpireCoalescer returns a coalescer that allows at most one EXPIRE per
 // `interval` per key. Starts a background sweeper that GC's stale entries
-// once per interval.
+// once per interval. Call Stop to release the sweeper goroutine.
 func NewExpireCoalescer(interval time.Duration, maxEntries int) *ExpireCoalescer {
-	e := &ExpireCoalescer{interval: interval, maxEntries: maxEntries}
-	go e.sweepLoop()
+	ctx, cancel := context.WithCancel(context.Background())
+	e := &ExpireCoalescer{interval: interval, maxEntries: maxEntries, stop: cancel}
+	go e.sweepLoop(ctx)
 	return e
+}
+
+// Stop terminates the background sweeper. Safe to call more than once.
+func (e *ExpireCoalescer) Stop() {
+	if e == nil || e.stop == nil {
+		return
+	}
+	e.stop()
 }
 
 // ShouldRefresh returns true if `interval` has passed since the last refresh
@@ -46,6 +65,10 @@ func (e *ExpireCoalescer) ShouldRefresh(key string) bool {
 	now := time.Now().UnixNano()
 	prev, loaded := e.m.LoadOrStore(key, now)
 	if !loaded {
+		// sync.Map.LoadOrStore is atomic: exactly one goroutine sees
+		// loaded=false for a given key, so the first-insertion path has no
+		// race.
+		e.size.Add(1)
 		e.Refreshed.Add(1)
 		return true
 	}
@@ -53,58 +76,65 @@ func (e *ExpireCoalescer) ShouldRefresh(key string) bool {
 		e.Skipped.Add(1)
 		return false
 	}
-	// Race-y but correct: two concurrent goroutines could both win the
-	// LoadOrStore path on the same key in the same interval. Result is one
-	// extra EXPIRE on a key under contention. Acceptable — EXPIRE is
-	// idempotent and this avoids a per-key mutex on the hot path.
+	// Real race lives here: under heavy contention several goroutines can
+	// each pass the post-interval check, each Store their own `now`, and
+	// each return true. That allows a small number of redundant EXPIREs on
+	// the same key in the same window. Acceptable: EXPIRE is idempotent and
+	// we avoid a per-key mutex on the hot path.
 	e.m.Store(key, now)
 	e.Refreshed.Add(1)
 	return true
 }
 
-func (e *ExpireCoalescer) sweepLoop() {
+func (e *ExpireCoalescer) sweepLoop(ctx context.Context) {
 	t := time.NewTicker(e.interval)
 	defer t.Stop()
-	for range t.C {
-		e.sweep()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			e.sweep()
+		}
 	}
 }
 
 func (e *ExpireCoalescer) sweep() {
-	count := 0
-	e.m.Range(func(_, _ any) bool {
-		count++
-		return true
-	})
-	if count < e.maxEntries {
+	if e.size.Load() < int64(e.maxEntries) {
 		return
 	}
 	cutoff := time.Now().Add(-2 * e.interval).UnixNano()
 	e.m.Range(func(k, v any) bool {
 		if v.(int64) < cutoff {
-			e.m.Delete(k)
+			if _, deleted := e.m.LoadAndDelete(k); deleted {
+				e.size.Add(-1)
+			}
 		}
 		return true
 	})
 }
 
-// Size returns the current number of cached keys. Used by metrics.
+// Size returns the current number of cached keys. O(1) via the atomic
+// counter — safe to call from a Prometheus scrape.
 func (e *ExpireCoalescer) Size() int {
-	n := 0
-	e.m.Range(func(_, _ any) bool {
-		n++
-		return true
-	})
-	return n
+	return int(e.size.Load())
 }
 
 // ExpireGate is the global coalescer used by the request handlers. Pre-
 // initialized with conservative defaults so handlers can call it without a
 // nil-check; main re-initializes with prod config on startup.
-var ExpireGate = NewExpireCoalescer(time.Hour, 1_000_000)
+var (
+	expireGateMu sync.Mutex
+	ExpireGate   = NewExpireCoalescer(time.Hour, 1_000_000)
+)
 
-// InitExpireGate wires the global coalescer. Safe to call more than once;
-// later calls replace the gate.
+// InitExpireGate replaces the global coalescer. Stops the previous gate's
+// sweeper so re-initialization doesn't leak goroutines.
 func InitExpireGate(interval time.Duration, maxEntries int) {
+	expireGateMu.Lock()
+	defer expireGateMu.Unlock()
+	if ExpireGate != nil {
+		ExpireGate.Stop()
+	}
 	ExpireGate = NewExpireCoalescer(interval, maxEntries)
 }

--- a/utils/expire_coalesce.go
+++ b/utils/expire_coalesce.go
@@ -1,0 +1,110 @@
+package utils
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// ExpireCoalescer suppresses redundant EXPIRE calls per key. The TTL we set
+// is BaseTTLPeriod (6 months), so refreshing more than once per hour per key
+// is pure waste — a key only loses its TTL if it's idle for the entire
+// 6-month window. At ~32 RPS sustained, EXPIRE was running 5.6M times/day,
+// nearly 1:1 with reads. This collapses it to roughly one call per active
+// key per `interval`.
+//
+// Multi-instance safe: each app instance keeps its own cache. If two
+// instances both decide to refresh in the same window for the same key, the
+// duplicate EXPIRE is idempotent. There is no cross-instance coordination
+// cost, which is the point.
+type ExpireCoalescer struct {
+	m        sync.Map // key string -> int64 unix-nano of last refresh
+	interval time.Duration
+
+	// Bounded eviction: when entries exceed maxEntries, the periodic sweeper
+	// drops anything older than 2*interval. Without this the map would grow
+	// without bound across the long tail of one-shot keys.
+	maxEntries int
+
+	Refreshed atomic.Uint64 // observed by Prometheus gauge
+	Skipped   atomic.Uint64
+}
+
+// NewExpireCoalescer returns a coalescer that allows at most one EXPIRE per
+// `interval` per key. Starts a background sweeper that GC's stale entries
+// once per interval.
+func NewExpireCoalescer(interval time.Duration, maxEntries int) *ExpireCoalescer {
+	e := &ExpireCoalescer{interval: interval, maxEntries: maxEntries}
+	go e.sweepLoop()
+	return e
+}
+
+// ShouldRefresh returns true if `interval` has passed since the last refresh
+// for `key`. The caller is expected to actually issue the EXPIRE on true.
+// Updates the last-refresh timestamp atomically.
+func (e *ExpireCoalescer) ShouldRefresh(key string) bool {
+	now := time.Now().UnixNano()
+	prev, loaded := e.m.LoadOrStore(key, now)
+	if !loaded {
+		e.Refreshed.Add(1)
+		return true
+	}
+	if time.Duration(now-prev.(int64)) < e.interval {
+		e.Skipped.Add(1)
+		return false
+	}
+	// Race-y but correct: two concurrent goroutines could both win the
+	// LoadOrStore path on the same key in the same interval. Result is one
+	// extra EXPIRE on a key under contention. Acceptable — EXPIRE is
+	// idempotent and this avoids a per-key mutex on the hot path.
+	e.m.Store(key, now)
+	e.Refreshed.Add(1)
+	return true
+}
+
+func (e *ExpireCoalescer) sweepLoop() {
+	t := time.NewTicker(e.interval)
+	defer t.Stop()
+	for range t.C {
+		e.sweep()
+	}
+}
+
+func (e *ExpireCoalescer) sweep() {
+	count := 0
+	e.m.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	if count < e.maxEntries {
+		return
+	}
+	cutoff := time.Now().Add(-2 * e.interval).UnixNano()
+	e.m.Range(func(k, v any) bool {
+		if v.(int64) < cutoff {
+			e.m.Delete(k)
+		}
+		return true
+	})
+}
+
+// Size returns the current number of cached keys. Used by metrics.
+func (e *ExpireCoalescer) Size() int {
+	n := 0
+	e.m.Range(func(_, _ any) bool {
+		n++
+		return true
+	})
+	return n
+}
+
+// ExpireGate is the global coalescer used by the request handlers. Pre-
+// initialized with conservative defaults so handlers can call it without a
+// nil-check; main re-initializes with prod config on startup.
+var ExpireGate = NewExpireCoalescer(time.Hour, 1_000_000)
+
+// InitExpireGate wires the global coalescer. Safe to call more than once;
+// later calls replace the gate.
+func InitExpireGate(interval time.Duration, maxEntries int) {
+	ExpireGate = NewExpireCoalescer(interval, maxEntries)
+}

--- a/utils/expire_coalesce_test.go
+++ b/utils/expire_coalesce_test.go
@@ -1,0 +1,138 @@
+package utils
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// First refresh for an unseen key must return true (gate starts open) and
+// bump Refreshed. A second call inside the window must return false and bump
+// Skipped without touching Refreshed.
+func TestExpireCoalescer_FirstRefreshIsAllowed(t *testing.T) {
+	e := NewExpireCoalescer(1*time.Hour, 1000)
+
+	require.True(t, e.ShouldRefresh("k1"), "first call for an unseen key must refresh")
+	require.Equal(t, uint64(1), e.Refreshed.Load())
+	require.Equal(t, uint64(0), e.Skipped.Load())
+
+	require.False(t, e.ShouldRefresh("k1"), "second call inside window must skip")
+	require.Equal(t, uint64(1), e.Refreshed.Load())
+	require.Equal(t, uint64(1), e.Skipped.Load())
+}
+
+// Per-key isolation: refreshing k1 must not affect k2's gate.
+func TestExpireCoalescer_PerKey(t *testing.T) {
+	e := NewExpireCoalescer(1*time.Hour, 1000)
+	require.True(t, e.ShouldRefresh("k1"))
+	require.True(t, e.ShouldRefresh("k2"), "k2 must refresh independently of k1")
+	require.False(t, e.ShouldRefresh("k1"))
+	require.False(t, e.ShouldRefresh("k2"))
+}
+
+// Once the window elapses, the next refresh must be allowed again.
+func TestExpireCoalescer_WindowElapses(t *testing.T) {
+	e := NewExpireCoalescer(10*time.Millisecond, 1000)
+	require.True(t, e.ShouldRefresh("k"))
+	require.False(t, e.ShouldRefresh("k"))
+	time.Sleep(15 * time.Millisecond)
+	require.True(t, e.ShouldRefresh("k"), "post-window refresh must be allowed again")
+}
+
+// Stress: many goroutines hammering the same key inside one window must yield
+// a tiny number of refreshes (ideally 1; the LoadOrStore + race tolerance can
+// allow a couple). The crucial property is that the gate is doing its job —
+// not >50% of calls returning true.
+func TestExpireCoalescer_ConcurrentSameKeySuppresses(t *testing.T) {
+	e := NewExpireCoalescer(10*time.Second, 1000)
+
+	const N = 2000
+	var wg sync.WaitGroup
+	var refreshed atomic.Int64
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if e.ShouldRefresh("hot") {
+				refreshed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// In practice you'll see 1 or 2 winners depending on goroutine scheduling.
+	// The point is N=2000 callers must NOT all see "refresh".
+	got := refreshed.Load()
+	require.LessOrEqual(t, got, int64(10),
+		"at most ~handful of refreshes should win, got %d/%d", got, N)
+	require.GreaterOrEqual(t, got, int64(1), "at least one caller must refresh")
+	require.Equal(t, int64(N)-got, int64(e.Skipped.Load()),
+		"every non-refresh must be counted as skipped")
+}
+
+// Distinct keys under concurrency must all be allowed once. This pins the
+// per-key isolation property — a buggy global mutex around the whole gate
+// would serialize them but still allow all to refresh; a buggy shared-counter
+// would let only one through.
+func TestExpireCoalescer_ConcurrentDistinctKeysAllRefresh(t *testing.T) {
+	e := NewExpireCoalescer(10*time.Second, 100_000)
+
+	const N = 500
+	var wg sync.WaitGroup
+	var refreshed atomic.Int64
+	for i := 0; i < N; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if e.ShouldRefresh("k" + strconv.Itoa(i)) {
+				refreshed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int64(N), refreshed.Load(), "every distinct key must get exactly one refresh")
+}
+
+// Size grows with distinct keys and the sweeper drops stale entries when over
+// the cap. We test sweep() directly so the test is fast and deterministic.
+func TestExpireCoalescer_SweeperEvictsStaleAboveCap(t *testing.T) {
+	e := NewExpireCoalescer(10*time.Millisecond, 5)
+
+	// Insert 10 keys, all "fresh".
+	for i := 0; i < 10; i++ {
+		require.True(t, e.ShouldRefresh("fresh"+strconv.Itoa(i)))
+	}
+	require.Equal(t, 10, e.Size())
+
+	// Sweep should be a no-op here — entries are fresher than 2*interval.
+	e.sweep()
+	require.Equal(t, 10, e.Size(), "fresh entries must survive sweep")
+
+	// Force entries to be old by waiting past 2*interval.
+	time.Sleep(25 * time.Millisecond)
+	e.sweep()
+	require.Equal(t, 0, e.Size(), "all stale entries above cap must be evicted")
+}
+
+// When map size is below cap, sweeper should not touch anything even if stale.
+// This is a deliberate design choice: don't pay for eviction if you don't need to.
+func TestExpireCoalescer_SweeperBelowCapDoesNotEvict(t *testing.T) {
+	e := NewExpireCoalescer(10*time.Millisecond, 1000)
+	e.ShouldRefresh("a")
+	e.ShouldRefresh("b")
+	time.Sleep(25 * time.Millisecond)
+	e.sweep()
+	require.Equal(t, 2, e.Size(), "below-cap sweeper must not touch stale entries")
+}
+
+// Default global gate exists immediately on package load so handlers never
+// hit a nil deref before main() runs InitExpireGate.
+func TestExpireGate_NotNilByDefault(t *testing.T) {
+	require.NotNil(t, ExpireGate, "ExpireGate must be initialized at package load")
+	require.True(t, ExpireGate.ShouldRefresh("sentinel-key-for-this-test-only"))
+}

--- a/utils/prometheus.go
+++ b/utils/prometheus.go
@@ -103,6 +103,36 @@ func InitPrometheus(ctx context.Context, addr string, main, rl *redis.Client) {
 		},
 	))
 
+	// EXPIRE coalescing visibility. The ratio Skipped / (Skipped+Refreshed)
+	// tells us how much Redis traffic the gate is saving.
+	Prom.registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Name: "abacus_expire_refreshed_total", Help: "EXPIRE calls actually issued (running total)."},
+		func() float64 {
+			if ExpireGate == nil {
+				return 0
+			}
+			return float64(ExpireGate.Refreshed.Load())
+		},
+	))
+	Prom.registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Name: "abacus_expire_skipped_total", Help: "EXPIRE calls suppressed by the coalescer (running total)."},
+		func() float64 {
+			if ExpireGate == nil {
+				return 0
+			}
+			return float64(ExpireGate.Skipped.Load())
+		},
+	))
+	Prom.registry.MustRegister(prometheus.NewGaugeFunc(
+		prometheus.GaugeOpts{Name: "abacus_expire_cache_size", Help: "Number of keys currently tracked by the EXPIRE coalescer."},
+		func() float64 {
+			if ExpireGate == nil {
+				return 0
+			}
+			return float64(ExpireGate.Size())
+		},
+	))
+
 	registerPoolGauges("main", main)
 	registerPoolGauges("ratelimit", rl)
 

--- a/utils/prometheus.go
+++ b/utils/prometheus.go
@@ -104,9 +104,11 @@ func InitPrometheus(ctx context.Context, addr string, main, rl *redis.Client) {
 	))
 
 	// EXPIRE coalescing visibility. The ratio Skipped / (Skipped+Refreshed)
-	// tells us how much Redis traffic the gate is saving.
-	Prom.registry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Name: "abacus_expire_refreshed_total", Help: "EXPIRE calls actually issued (running total)."},
+	// tells us how much Redis traffic the gate is saving. These are running
+	// totals so they're exposed as Counters (matching the _total suffix) —
+	// rate() and increase() will work correctly across scrapes.
+	Prom.registry.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{Name: "abacus_expire_refreshed_total", Help: "EXPIRE calls actually issued (cumulative)."},
 		func() float64 {
 			if ExpireGate == nil {
 				return 0
@@ -114,8 +116,8 @@ func InitPrometheus(ctx context.Context, addr string, main, rl *redis.Client) {
 			return float64(ExpireGate.Refreshed.Load())
 		},
 	))
-	Prom.registry.MustRegister(prometheus.NewGaugeFunc(
-		prometheus.GaugeOpts{Name: "abacus_expire_skipped_total", Help: "EXPIRE calls suppressed by the coalescer (running total)."},
+	Prom.registry.MustRegister(prometheus.NewCounterFunc(
+		prometheus.CounterOpts{Name: "abacus_expire_skipped_total", Help: "EXPIRE calls suppressed by the coalescer (cumulative)."},
 		func() float64 {
 			if ExpireGate == nil {
 				return 0


### PR DESCRIPTION
## Summary

Two changes that should together kill the pool-timeout cliff visible in the dashboard (42k+ timeouts/day) and cut Redis traffic roughly in half.

### 1. `perf: bump Redis pool to 100 and tighten timeouts`

The default `PoolSize` of 10 was getting exhausted at our sustained 32-36 RPS, with each cross-region RTT holding a connection for several ms. Result: **42,041 pool timeouts on the main pool and 6,583 on ratelimit over 2 days**, each one sitting for the full 4s default before failing. That dragged average command latency into the hundreds of ms despite Redis itself being healthy.

New defaults:
- `PoolSize: 100` — Redis is dedicated to this app, plenty of headroom
- `MinIdleConns: 10` — pool stays warm, no TLS handshake on bursts
- `ReadTimeout: 500ms`, `WriteTimeout: 500ms`
- `PoolTimeout: 1.2s` — fail-fast instead of the 4s default

### 2. `perf: coalesce EXPIRE refreshes per-key`

`BaseTTLPeriod` is 6 months. Issuing one EXPIRE per read meant **5.6M EXPIRE calls/day**, nearly 1:1 with GETs. That's pure waste: a key only loses its TTL if it's idle for 6 months straight, so refreshing more than once per hour is meaningless.

`ExpireCoalescer` keeps a per-instance `sync.Map` of last-refresh timestamps. `ShouldRefresh(key)` returns true once per `interval` (default 1h, configurable via `EXPIRE_COALESCE_INTERVAL`). The four call sites in `HitView`, `HitShieldView`, `GetView`, and `GetShieldView` now skip the EXPIRE when the gate says no.

Multi-instance safe: each instance keeps its own cache. Cross-instance duplicate refreshes are idempotent and there's no coordination cost.

Background sweeper drops entries older than `2*interval` once the map exceeds `maxEntries` (default 1M).

### 3. Tests for the coalescer

Pins the invariants that matter:
- first refresh allowed, second inside window skipped
- per-key isolation
- window-elapse re-opens the gate
- 2000 concurrent goroutines on one hot key produce at most a handful of refreshes (not all 2000)
- distinct keys under concurrency each get exactly one refresh
- sweeper evicts only when above cap AND entries are stale
- global `ExpireGate` is non-nil at package load

### 4. Prometheus visibility

Three new gauges so we can prove the gate is doing its job:
- `abacus_expire_refreshed_total` — EXPIREs actually sent
- `abacus_expire_skipped_total` — EXPIREs suppressed
- `abacus_expire_cache_size` — keys currently tracked

The ratio `skipped / (skipped + refreshed)` should sit at >0.95 once warm.

## Expected impact

- Pool timeouts on the main dashboard go to zero (or near it).
- `abacus_redis_cmd_duration_seconds` p99 drops dramatically — averages were being dominated by 4-second pool-timeout failures.
- Total Redis ops/day on the main pool roughly halves (EXPIRE was ~50% of traffic).

## Test plan

- [x] `go test -race ./...` passes
- [x] New unit tests cover ExpireCoalescer (8 tests, including concurrency)
- [ ] Deploy and watch:
  - `abacus_redis_pool_timeouts` should stop incrementing
  - `abacus_expire_skipped_total / (skipped + refreshed)` should climb above 0.9 within minutes
  - Redis p99 panel on Grafana should drop visibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)