### PR TITLE
perf: widen latency buckets to 30s and pin VM at 2 vCPU / 512MB

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -29,9 +29,9 @@ timeout = "5s"
 path = "/healthcheck"
 
 [[vm]]
-  memory_mb = 256
+  memory_mb = 512
   cpu_kind = 'shared'
-  cpus = 1
+  cpus = 2
 
 [deploy]
 strategy = "bluegreen"

--- a/utils/prometheus.go
+++ b/utils/prometheus.go
@@ -28,7 +28,12 @@ var Prom = struct {
 		prometheus.HistogramOpts{
 			Name:    "abacus_redis_cmd_duration_seconds",
 			Help:    "Redis command latency, by pool and command name.",
-			Buckets: prometheus.ExponentialBucketsRange(0.0001, 2.0, 14), // 100us .. 2s
+			// 20 exponential buckets from 100µs to 30s. The previous 2s ceiling
+			// hid actual tail latency during Redis brownouts — the histogram
+			// would report "2.00s" for every slow cmd because anything past 2s
+			// landed in +Inf and histogram_quantile clamps to the top finite
+			// bucket. 30s covers the worst plausible pool-timeout + retry case.
+			Buckets: prometheus.ExponentialBucketsRange(0.0001, 30.0, 20),
 		},
 		[]string{"pool", "cmd"},
 	),


### PR DESCRIPTION
## Summary

Two small changes informed by the latency spike earlier today.

### 1. Widen Redis latency histogram to 30s, 20 buckets

The previous histogram capped at 2s. During this morning's brownout, the dashboard showed every command pinned to exactly **2.00s** — that wasn't real, it was the bucket ceiling. `histogram_quantile()` clamps to the top *finite* bucket and everything past 2s landed in `+Inf`. We were flying blind on how bad the tail actually got.

New buckets: `prometheus.ExponentialBucketsRange(0.0001, 30.0, 20)` — sub-ms resolution at the healthy end, second-level resolution at the brownout end. Growth factor ~1.93× per bucket gives meaningful p50/p95/p99 across the full dynamic range we actually care about.

Cardinality cost: 20 buckets × 2 pools × ~12 commands = ~480 series for this metric. Acceptable.

### 2. Pin fly.toml at 2 vCPU / 512MB

You bumped the VM via the Fly UI earlier — this just makes the config the source of truth so future deploys don't silently revert it. The reason this matters for the cascade we saw:

- Goroutine dump during the spike showed **234 runnable goroutines** competing for one CPU. The scheduler queue itself became a bottleneck.
- Doubling cores doesn't double throughput, but it does drain runnable-state goroutines roughly twice as fast and lets CPU-bound work (JSON marshal, middleware) actually parallelize.

512MB memory is mostly headroom — peak RSS during the cascade was 116MB, nowhere near the old 256MB ceiling. Cheap insurance against goroutine-stack growth in future cascades + EXPIRE coalescer map at 1M entries.

## Test plan

- [x] `go build ./...` passes
- [ ] Deploy and confirm:
  - Latency dashboard shows actual values past 2s during the next spike (not pinned)
  - Goroutine count graph (if anyone adds one) stays bounded with 2 cores
  - VM stays at 2 cpu / 512MB across redeploys

## Follow-ups (not in this PR)

- `MaxRetries: 1` on the Redis client to stop amplifying brownouts via library-internal retries
- In-process rate limiter so the app survives Redis brownouts at all (currently the rate limiter itself depends on Redis being up)
- Redis-side metrics (redis_exporter) so we can see if it's BGSAVE / AOF rewrite / memory pressure causing the spikes

🤖 Generated with [Claude Code](https://claude.com/claude-code)