### PR TITLE
feat(metrics): per-endpoint HTTP latency histogram with cardinality guard

### DIFF
--- a/main.go
+++ b/main.go
@@ -257,6 +257,10 @@ func CreateRouter() *gin.Engine {
 
 	r.Use(cors.New(corsConfig))
 	r.Use(gin.Recovery()) // recover from panics and returns a 500 error
+	// Prometheus must run AFTER Recovery so it sees the post-recovery 500
+	// status, and BEFORE Stats/RateLimit/handlers so it measures the full
+	// request time including those middlewares.
+	r.Use(middleware.Prometheus())
 	if os.Getenv("API_ANALYTICS_ENABLED") == "true" {
 		r.Use(analytics.Analytics(os.Getenv("API_ANALYTICS_KEY"))) // Add middleware
 		log.Println("Analytics enabled")

--- a/middleware/prometheus.go
+++ b/middleware/prometheus.go
@@ -1,0 +1,80 @@
+package middleware
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"pkg.jsn.cam/abacus/utils"
+)
+
+// Prometheus returns a gin middleware that records request latency into
+// utils.Prom.HTTPRequestDur.
+//
+// Cardinality-safety contract — DO NOT BREAK THESE WHEN EDITING:
+//
+//   - The "route" label is c.FullPath(), the gin route TEMPLATE. The raw URL
+//     path (c.Request.URL.Path) contains the namespace and key segments which
+//     come from user input. Labeling by the raw path would create one time
+//     series per (namespace, key) pair — unbounded — and OOM Prometheus.
+//
+//   - For requests that don't match any registered route, FullPath() returns
+//     "". We bucket those as "unmatched" so they remain observable as a
+//     single series without leaking the raw URL.
+//
+//   - The "status" label is the response code's CLASS (e.g. "2xx", "4xx",
+//     "5xx"), not the exact code. Class-based labeling keeps cardinality
+//     bounded at ~5 values forever; full status codes would slowly accumulate
+//     every unusual response gin emits (304, 405, 429, 503, …) without
+//     adding alerting signal.
+//
+//   - The "method" label is bounded by HTTP itself (~9 verbs).
+//
+// Worst-case cardinality: ~10 routes × ~5 methods × 5 status classes × 20
+// histogram buckets ≈ 5000 series. Safe.
+//
+// Skipped routes: /healthcheck and /metrics. They're scraped on fixed timers
+// (Fly's health check every 30s, Fly's Prometheus every 15s) and would
+// dominate the count without telling us anything about user-facing latency.
+func Prometheus() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		path := c.Request.URL.Path
+		if path == "/healthcheck" || path == "/metrics" {
+			c.Next()
+			return
+		}
+
+		start := time.Now()
+		c.Next()
+
+		route := c.FullPath()
+		if route == "" {
+			route = "unmatched"
+		}
+
+		utils.Prom.HTTPRequestDur.
+			WithLabelValues(c.Request.Method, route, statusClass(c.Writer.Status())).
+			Observe(time.Since(start).Seconds())
+	}
+}
+
+// statusClass collapses an HTTP status code into a small bounded class label.
+func statusClass(code int) string {
+	switch {
+	case code >= 500:
+		return "5xx"
+	case code >= 400:
+		return "4xx"
+	case code >= 300:
+		return "3xx"
+	case code >= 200:
+		return "2xx"
+	case code >= 100:
+		return "1xx"
+	default:
+		// gin returns 0 if the handler never wrote a response (rare, but
+		// possible during a panic before Recovery kicks in). Bucket it
+		// distinctly so it's noticed.
+		return "unknown"
+	}
+}

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -1,0 +1,176 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"pkg.jsn.cam/abacus/utils"
+)
+
+// metricLabelCombos returns the number of unique label combinations currently
+// stored for the abacus_http_request_duration_seconds metric. One combination
+// of (method, route, status) = one time series in Prometheus.
+func metricLabelCombos(t *testing.T) (int, []string) {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 4096)
+	go func() {
+		utils.Prom.HTTPRequestDur.Collect(ch)
+		close(ch)
+	}()
+	seen := map[string]bool{}
+	var combos []string
+	for m := range ch {
+		var dtoMetric dto.Metric
+		require.NoError(t, m.Write(&dtoMetric))
+		var parts []string
+		for _, lp := range dtoMetric.Label {
+			parts = append(parts, lp.GetName()+"="+lp.GetValue())
+		}
+		key := strings.Join(parts, ",")
+		if !seen[key] {
+			seen[key] = true
+			combos = append(combos, key)
+		}
+	}
+	return len(seen), combos
+}
+
+func newTestRouterWithRoutes() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Prometheus())
+	// Mirror the real routes shape so c.FullPath() returns parameterized templates.
+	r.GET("/hit/:namespace/:key", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	r.GET("/get/:namespace/:key", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	r.POST("/create/:namespace/*key", func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
+	r.GET("/info/:namespace/*key", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	r.GET("/healthcheck", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	return r
+}
+
+func resetMetric() {
+	utils.Prom.HTTPRequestDur.Reset()
+}
+
+// THE invariant: spamming 1,000 distinct (namespace, key) pairs against the
+// same route template must produce exactly ONE time series, not 1,000.
+// If this ever fails, someone replaced c.FullPath() with c.Request.URL.Path.
+func TestPrometheus_UserGeneratedKeysDoNotExplodeCardinality(t *testing.T) {
+	resetMetric()
+	r := newTestRouterWithRoutes()
+
+	for i := 0; i < 1000; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/hit/ns/key"+strconv.Itoa(i), nil)
+		r.ServeHTTP(w, req)
+	}
+
+	count, combos := metricLabelCombos(t)
+	require.Equal(t, 1, count,
+		"1000 distinct keys against one route template must produce ONE series, got %d: %v",
+		count, combos)
+	require.Contains(t, combos[0], "route=/hit/:namespace/:key",
+		"route label must be the template, not a concrete path")
+}
+
+// 404s for unknown URLs must collapse into a single "unmatched" series.
+// Without this, attackers probing random URLs would inflate cardinality.
+func TestPrometheus_UnmatchedRoutesBucketedTogether(t *testing.T) {
+	resetMetric()
+	r := newTestRouterWithRoutes()
+
+	for i := 0; i < 50; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/no/such/route/"+strconv.Itoa(i), nil)
+		r.ServeHTTP(w, req)
+	}
+
+	count, combos := metricLabelCombos(t)
+	require.Equal(t, 1, count, "50 unmatched URLs must collapse to one series, got: %v", combos)
+	require.Contains(t, combos[0], "route=unmatched")
+}
+
+// Status codes must collapse into classes. 200, 201, 204 → "2xx" (one series),
+// not three. Same for 400/401/404 → "4xx".
+func TestPrometheus_StatusCodesCollapseIntoClasses(t *testing.T) {
+	resetMetric()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(Prometheus())
+	r.GET("/x", func(c *gin.Context) {
+		code, _ := strconv.Atoi(c.Query("code"))
+		c.JSON(code, gin.H{"ok": true})
+	})
+
+	for _, code := range []int{200, 201, 204, 400, 401, 404, 500, 502, 503} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/x?code="+strconv.Itoa(code), nil)
+		r.ServeHTTP(w, req)
+	}
+
+	count, combos := metricLabelCombos(t)
+	// Expected: 3 series (2xx, 4xx, 5xx), all method=GET, route=/x.
+	require.Equal(t, 3, count, "9 status codes across 3 classes must produce 3 series, got: %v", combos)
+}
+
+// /healthcheck and /metrics must be excluded entirely — they're scraped on
+// fixed timers and would dominate the bucket counts.
+func TestPrometheus_ExcludedRoutesNotRecorded(t *testing.T) {
+	resetMetric()
+	r := newTestRouterWithRoutes()
+
+	// Hit healthcheck many times.
+	for i := 0; i < 100; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/healthcheck", nil)
+		r.ServeHTTP(w, req)
+	}
+
+	// Also hit a real route once so the metric isn't entirely empty.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/get/ns/key", nil))
+
+	count, combos := metricLabelCombos(t)
+	require.Equal(t, 1, count, "healthcheck must be excluded; only /get should remain. got: %v", combos)
+	require.NotContains(t, combos[0], "/healthcheck")
+}
+
+// Realistic upper bound check: simulate everything the real app might emit
+// and assert total label combinations stay under a sane budget. If a future
+// change accidentally adds a high-cardinality label, this fails loudly.
+func TestPrometheus_TotalCardinalityStaysUnderBudget(t *testing.T) {
+	resetMetric()
+	r := newTestRouterWithRoutes()
+
+	// Exercise every (route, method) pair plus a few status classes.
+	requests := []struct {
+		method, path string
+	}{
+		{"GET", "/hit/a/b"}, {"GET", "/hit/c/d"},
+		{"GET", "/get/a/b"}, {"GET", "/get/c/d"},
+		{"POST", "/create/a/b"}, {"POST", "/create/c/d"},
+		{"GET", "/info/a/b"}, {"GET", "/info/c/d"},
+		{"GET", "/bogus"}, // unmatched 404
+		{"DELETE", "/hit/a/b"}, // wrong method = 404
+	}
+	for _, r2 := range requests {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(r2.method, r2.path, nil)
+		r.ServeHTTP(w, req)
+	}
+
+	count, combos := metricLabelCombos(t)
+	// The real app has ~10 routes, ~4 methods, 5 status classes.
+	// Even at maximum hypothetical use that's ~200 combinations. Anything
+	// above 50 in this test would mean a regression in label discipline.
+	require.LessOrEqual(t, count, 50,
+		"label cardinality must stay bounded — got %d combos: %v", count, combos)
+}

--- a/utils/prometheus.go
+++ b/utils/prometheus.go
@@ -23,7 +23,24 @@ var Prom = struct {
 	redisCmdErrors   *prometheus.CounterVec
 	sseClientDrops   prometheus.Counter
 	sseMessageDrops  prometheus.Counter
+	HTTPRequestDur   *prometheus.HistogramVec
 }{
+	HTTPRequestDur: prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "abacus_http_request_duration_seconds",
+			Help: "End-to-end HTTP request latency per route, method, and status class.",
+			// Same shape as the Redis histogram. App-level latency is dominated
+			// by Redis time + a few hundred µs of gin/middleware overhead, so
+			// the same 100µs-to-30s range covers both healthy and brownout cases.
+			Buckets: prometheus.ExponentialBucketsRange(0.0001, 30.0, 20),
+		},
+		// route is the gin route TEMPLATE (e.g. "/hit/:namespace/:key"), not
+		// the raw URL — otherwise label cardinality is unbounded across the
+		// user-generated key space. status is the status class (2xx/4xx/5xx)
+		// for the same reason. See middleware/prometheus.go for the
+		// cardinality-safety contract.
+		[]string{"method", "route", "status"},
+	),
 	redisCmdDuration: prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "abacus_redis_cmd_duration_seconds",
@@ -70,6 +87,7 @@ func InitPrometheus(ctx context.Context, addr string, main, rl *redis.Client) {
 		Prom.redisCmdErrors,
 		Prom.sseClientDrops,
 		Prom.sseMessageDrops,
+		Prom.HTTPRequestDur,
 	)
 
 	// Live-read gauges. GaugeFunc evaluates on every scrape, so we don't need


### PR DESCRIPTION
## Summary

Adds `abacus_http_request_duration_seconds` — a Prometheus `HistogramVec` labeled by `(method, route, status)`. This lets the Grafana dashboard answer **\"what's p99 on /hit right now\"**, which until today lived only in Sentry's 5%-sampled transactions with no way to overlay against Redis latency.

The PromQL pattern is the same as the existing Redis histogram:
```promql
histogram_quantile(0.99,
  sum by (route, le) (rate(abacus_http_request_duration_seconds_bucket[$__rate_interval]))
)
```

## The cardinality-safety contract

This is the load-bearing detail. Three rules, each enforced by both the code AND a test:

1. **`route` is `c.FullPath()` (route template), never `c.Request.URL.Path` (raw URL).** Raw paths embed user-generated namespace/key segments. Labeling by them would create one time series per pair → unbounded → Prometheus OOM. Test `TestPrometheus_UserGeneratedKeysDoNotExplodeCardinality` spams 1000 distinct (ns, key) pairs and asserts exactly **one** series.

2. **`status` is the class (`2xx`/`4xx`/`5xx`), not the exact code.** Test `TestPrometheus_StatusCodesCollapseIntoClasses` sends 9 distinct codes and asserts 3 series.

3. **Unmatched routes bucket under `route=\"unmatched\"`.** 404 probing against random URLs doesn't inflate cardinality. Test `TestPrometheus_UnmatchedRoutesBucketedTogether` hammers 50 unique unknown URLs and asserts 1 series.

Worst-case math: ~10 routes × ~5 methods × 5 status classes × 20 histogram buckets ≈ **5,000 series**.

## Excluded routes

`/healthcheck` and `/metrics` are skipped — both are scraped on fixed timers (Fly health every 30s, Fly Prometheus every 15s) and would dominate request counts without telling us anything useful about user-facing latency. Test `TestPrometheus_ExcludedRoutesNotRecorded` verifies.

## Middleware order

`gin.Recovery()` → `middleware.Prometheus()` → `Stats` → `RateLimit` → handlers. After Recovery so the histogram sees post-recovery 500 statuses. Before everything else so it measures the full request time including all subsequent middleware overhead.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (excluding pre-existing `TestStreamValueView` race)
- [x] All 5 cardinality contract tests pass
- [ ] After deploy: hit a few endpoints, query Prometheus, verify per-route series appear
- [ ] Dashboard follow-up PR adds the panels

## What this PR does NOT do

- Doesn't add Grafana panels — separate PR with `docs/grafana-dashboard.json` update.
- Doesn't change anything about the existing Redis cmd histogram or any other metric.
- Doesn't touch Sentry — the stripping-tracing PR is coming next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)