### PR TITLE
fix(metrics): exclude /stream SSE from HTTP request histogram

### DIFF
--- a/middleware/prometheus.go
+++ b/middleware/prometheus.go
@@ -33,13 +33,22 @@ import (
 // Worst-case cardinality: ~10 routes × ~5 methods × 5 status classes × 20
 // histogram buckets ≈ 5000 series. Safe.
 //
-// Skipped routes: /healthcheck and /metrics. They're scraped on fixed timers
-// (Fly's health check every 30s, Fly's Prometheus every 15s) and would
-// dominate the count without telling us anything about user-facing latency.
+// Skipped routes (matched on c.FullPath(), the route template):
+//
+//   - /healthcheck: scraped by Fly every 30s, would dominate the count
+//     without telling us anything about user-facing latency.
+//
+//   - /stream/:namespace/*key: SSE long-lived connections held open for
+//     the lifetime of the subscriber. Recording these in the same histogram
+//     as fast request/response endpoints would land every sample in the
+//     +Inf / 30s buckets and poison the global p50/p95/p99 math.
+//
+// (/metrics isn't listed because it's served on a separate :9091 listener
+// outside the gin router, so it never reaches this middleware.)
 func Prometheus() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		path := c.Request.URL.Path
-		if path == "/healthcheck" || path == "/metrics" {
+		switch c.FullPath() {
+		case "/healthcheck", "/stream/:namespace/*key":
 			c.Next()
 			return
 		}

--- a/middleware/prometheus_test.go
+++ b/middleware/prometheus_test.go
@@ -53,6 +53,10 @@ func newTestRouterWithRoutes() *gin.Engine {
 	r.POST("/create/:namespace/*key", func(c *gin.Context) { c.JSON(http.StatusCreated, gin.H{"ok": true}) })
 	r.GET("/info/:namespace/*key", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
 	r.GET("/healthcheck", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+	// SSE endpoint — same route shape as the real /stream/:namespace/*key.
+	// Handler just writes immediately; the test only cares that the histogram
+	// records (or doesn't record) it, not that it actually streams.
+	r.GET("/stream/:namespace/*key", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
 	return r
 }
 
@@ -121,26 +125,51 @@ func TestPrometheus_StatusCodesCollapseIntoClasses(t *testing.T) {
 	require.Equal(t, 3, count, "9 status codes across 3 classes must produce 3 series, got: %v", combos)
 }
 
-// /healthcheck and /metrics must be excluded entirely — they're scraped on
-// fixed timers and would dominate the bucket counts.
-func TestPrometheus_ExcludedRoutesNotRecorded(t *testing.T) {
+// /healthcheck must be excluded entirely — Fly scrapes it on a fixed timer
+// and it would dominate the bucket counts without telling us anything about
+// user-facing latency.
+func TestPrometheus_HealthcheckNotRecorded(t *testing.T) {
 	resetMetric()
 	r := newTestRouterWithRoutes()
 
-	// Hit healthcheck many times.
 	for i := 0; i < 100; i++ {
 		w := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/healthcheck", nil)
-		r.ServeHTTP(w, req)
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/healthcheck", nil))
 	}
 
-	// Also hit a real route once so the metric isn't entirely empty.
+	// Hit a real route once so the metric isn't entirely empty.
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, httptest.NewRequest("GET", "/get/ns/key", nil))
 
 	count, combos := metricLabelCombos(t)
 	require.Equal(t, 1, count, "healthcheck must be excluded; only /get should remain. got: %v", combos)
 	require.NotContains(t, combos[0], "/healthcheck")
+}
+
+// SSE (/stream/:namespace/*key) must be excluded entirely. Connections are
+// held open for the lifetime of the subscriber. Recording them in the same
+// histogram as request/response endpoints would land every sample in the
+// top buckets (15s/30s/+Inf) and poison the global percentile math on every
+// other panel.
+func TestPrometheus_SSENotRecorded(t *testing.T) {
+	resetMetric()
+	r := newTestRouterWithRoutes()
+
+	// Hit the SSE route a bunch.
+	for i := 0; i < 10; i++ {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest("GET", "/stream/ns/key", nil))
+	}
+
+	// Hit a real route once so the metric isn't entirely empty.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, httptest.NewRequest("GET", "/get/ns/key", nil))
+
+	count, combos := metricLabelCombos(t)
+	require.Equal(t, 1, count, "SSE must be excluded; only /get should remain. got: %v", combos)
+	for _, c := range combos {
+		require.NotContains(t, c, "/stream", "SSE route must not appear in histogram labels")
+	}
 }
 
 // Realistic upper bound check: simulate everything the real app might emit


### PR DESCRIPTION
## Why

SSE connections at `/stream/:namespace/*key` are held open for the lifetime of the subscriber. Every sample lands in the top histogram buckets (15s / 30s / `+Inf`) and **poisons the global p50/p95/p99 math on every panel that doesn't filter by route**.

Right now the live `/metrics` shows 5 SSE samples — tiny. But under any real SSE usage this would dominate the entire HTTP histogram. Better to fix before it bites.

## How

Two-line behavior change:
- Switch the skip check from raw-URL matching to `c.FullPath()` matching, so the skip is expressed against the route **template** — the same string the rest of the middleware uses for the `route` label. Consistent and explicit.
- Add `/stream/:namespace/*key` to the skip list alongside `/healthcheck`.

Also cleaned up dead code: removed the `/metrics` check. `/metrics` is served on the `:9091` listener outside the gin router, so it never reaches this middleware.

## Tests

`TestPrometheus_SSENotRecorded` (new) — fires 10 requests at `/stream/ns/key` and one at `/get/ns/key`, asserts only `/get` appears in the histogram and that no label combo contains `/stream`. The existing exclusion test split into per-route tests (`TestPrometheus_HealthcheckNotRecorded`, `TestPrometheus_SSENotRecorded`) so failure modes don't conflate.

`newTestRouterWithRoutes` now registers `/stream/:namespace/*key` so `c.FullPath()` returns the real template during tests — without this, the FullPath-based skip check wouldn't be exercised the way it is in production.

## Test plan

- [x] `go test -race ./middleware/` passes (6 cardinality tests, all green)
- [x] `go test -race ./...` (full suite, excluding the pre-existing `TestStreamValueView` race) passes
- [ ] After deploy: confirm `/stream` no longer appears in `abacus_http_request_duration_seconds_count` label set on the live `/metrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)