### PR TITLE
perf(redis): MaxRetries=1, cap retry backoff at 100ms

### DIFF
--- a/main.go
+++ b/main.go
@@ -96,6 +96,15 @@ func init() {
 			ReadTimeout:  500 * time.Millisecond,
 			WriteTimeout: 500 * time.Millisecond,
 			PoolTimeout:  1200 * time.Millisecond,
+			// go-redis defaults to 3 retries with backoff up to 512ms. During
+			// a Redis brownout this amplifies the cascade — each failing call
+			// holds a pool slot for retry₁ + backoff₁ + retry₂ + backoff₂ +
+			// retry₃ (up to ~2s) instead of just failing. One retry is enough
+			// to cover transient single-connection drops without turning the
+			// library into a cascade amplifier.
+			MaxRetries:      1,
+			MinRetryBackoff: 8 * time.Millisecond,
+			MaxRetryBackoff: 100 * time.Millisecond, // default 512ms is too patient under load
 		}
 	}
 	Client = redis.NewClient(poolOpts(DbNum))


### PR DESCRIPTION
## Why

`go-redis` defaults to **3 retries with exponential backoff up to 512ms**. That's the right default for short-lived scripts but the wrong default for a high-throughput service with a small pool. During a Redis brownout the retry sequence becomes a cascade amplifier:

```
1 slow call →
  retry1 + backoff1 (8–512ms) +
  retry2 + backoff2 (16–512ms) +
  retry3 = up to ~2 seconds of held pool slot
```

A single failing connection at 100 RPS becomes a ~200-slot pool drain within ~2 seconds. The pool you upsized to 100 conns can be exhausted by 50 in-flight retry sequences. This is why we keep cascading.

## What

Three lines, both Redis clients:

```go
MaxRetries:      1,                       // was default 3
MinRetryBackoff: 8  * time.Millisecond,   // default — explicit for clarity
MaxRetryBackoff: 100 * time.Millisecond,  // was default 512ms
```

**Why 1, not 0:** Transient single-connection drops (TCP RST, TLS rehandshake, brief network blip) genuinely benefit from one retry. Going to zero would surface them all as 5xx to the user. One retry covers the legitimate cases without compounding pool pressure.

**Why cap MaxRetryBackoff:** Even with one retry, holding a pool slot for 512ms during a brownout is too long. 100ms is plenty for transient blips and short enough that the retry can't dominate request latency.

## go-redis quirk worth knowing

```
MaxRetries:  0 →  defaults to 3 (treated as "unset")
MaxRetries: -1 →  no retries at all
MaxRetries:  1 →  exactly one retry
```

Verified directly from `~/go/pkg/mod/github.com/redis/go-redis/v9@v9.19.0/options.go:392-397`. Setting `MaxRetries: 1` explicitly to avoid the default-resurrection trap.

## What this won't fix

This is one piece of the cascade-mitigation puzzle. The other two — in-process micro-cache for `/get` and in-memory rate limiter — are still the bigger levers given today's traffic shape (~330 hot keys serving 408k GETs). But this is the smallest, safest change and worth shipping independently because:

- No new code paths, no new dependencies, no test changes
- Effect is measurable immediately on `pool_timeouts` rate
- Doesn't depend on or block the other two PRs

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` (full suite, excluding pre-existing `TestStreamValueView` race) passes
- [ ] After deploy, during the next brownout, check the Grafana dashboard:
  - Pool timeout rate should be lower than it was during the last cascade at equivalent traffic
  - `histogram_quantile(0.99, rate(abacus_redis_cmd_duration_seconds_bucket[5m]))` should not exceed ~2s during the brownout (was hitting bucket ceiling at 2s previously, which mapped to "real latency ≥2s, unknown how much more" — now bounded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)